### PR TITLE
feat: make the add command more flexible with a prompt-based system

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ The fastest way to get started is with the CLI tool:
    npx @craftreactnative/ui add --all
    ```
 
+   During `add`, the CLI asks a few setup questions once per run:
+   - component file structure: single file, 3 files, or 4 files
+   - destination path: default `craftrn-ui/components` or a custom project-relative path
+   - index/barrel strategy:
+     - per component (`index.ts` in each component folder)
+     - components folder barrel (single `index.ts` in the components root)
+     - no index files
+
+   This helps match your project conventions without extra flags.
+
 3. **Start building** with fully typed, theme-aware components!
 
 ## Available Components

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
+        "@clack/prompts": "^1.1.0",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "fs-extra": "^11.2.0",
@@ -22,7 +23,7 @@
         "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.29.6",
         "@types/fs-extra": "^11.0.4",
-        "@types/node": "^20.10.5",
+        "@types/node": "^20.19.37",
         "typescript": "^5.3.3"
       }
     },
@@ -512,6 +513,25 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/@clack/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==",
+      "license": "MIT",
+      "dependencies": {
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.1.0.tgz",
+      "integrity": "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.1.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
@@ -718,9 +738,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
-      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1866,6 +1886,12 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -43,6 +43,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@clack/prompts": "^1.1.0",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "fs-extra": "^11.2.0",
@@ -53,7 +54,7 @@
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.6",
     "@types/fs-extra": "^11.0.4",
-    "@types/node": "^20.10.5",
+    "@types/node": "^20.19.37",
     "typescript": "^5.3.3"
   },
   "files": [

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,6 +6,7 @@ import { addCommand } from "./commands/add";
 import { initCommand } from "./commands/init";
 import { getAvailableComponents, setLatestFlag } from "./utils/component-manager";
 import { ensureProjectRoot } from "./utils/project-detection";
+import { collectUserPreferences } from "./utils/prompts";
 
 // Function to get version from package.json
 function getPackageVersion(): string {
@@ -59,10 +60,16 @@ program
   .action(async (componentNames: string[], options) => {
     try {
       await ensureProjectRoot();
-      
+
       // Pass latest flag to component manager
       if (options.latest) {
         setLatestFlag(true);
+      }
+
+      // ── Interactive prompts (runs once before any installation) ──────────
+      const preferences = await collectUserPreferences();
+      if (!preferences) {
+        process.exit(0);
       }
 
       if (options.all) {
@@ -88,6 +95,9 @@ program
             componentName,
             force: options.force,
             all: options.all,
+            fileSplitMode: preferences.fileSplitMode,
+            componentsPath: preferences.componentsPath,
+            barrelFileMode: preferences.barrelFileMode,
           });
           if (success) {
             successCount++;
@@ -133,6 +143,9 @@ program
           const success = await addCommand(componentName, {
             componentName,
             force: options.force,
+            fileSplitMode: preferences.fileSplitMode,
+            componentsPath: preferences.componentsPath,
+            barrelFileMode: preferences.barrelFileMode,
           });
           if (success) {
             successCount++;

--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -1,22 +1,32 @@
-import * as fs from "fs-extra";
-import * as path from "path";
 import chalk from "chalk";
+import * as fs from "fs-extra";
 import ora from "ora";
-import { InstallOptions } from "../types";
+import * as path from "path";
+import { DEFAULT_COMPONENTS_PATH, InstallOptions } from "../types";
+import { applyBarrelFileMode } from "../utils/barrel-manager";
 import {
-  getComponentInfo,
-  resolveDependencies,
   copyComponent,
   getAvailableComponents,
+  getComponentInfo,
+  resolveDependencies,
 } from "../utils/component-manager";
-import { initCommand } from "./init";
+import { splitComponentFiles } from "../utils/file-splitter";
 import { determineImportPath } from "../utils/file-system";
+import { initCommand } from "./init";
+
+function toPosixPath(value: string): string {
+  return value.replace(/\\+/g, "/").replace(/\/+$/, "");
+}
 
 export async function addCommand(
   componentName: string,
   options: Partial<InstallOptions> = {}
 ): Promise<boolean> {
   const targetPath = process.cwd();
+  const componentsBasePath = toPosixPath(
+    options.componentsPath || DEFAULT_COMPONENTS_PATH
+  );
+  const barrelFileMode = options.barrelFileMode || "component";
 
   // Check if craftrn-ui folder exists, if not, run init
   const craftrnUiPath = path.join(targetPath, "craftrn-ui");
@@ -67,8 +77,7 @@ export async function addCommand(
     for (const dep of dependencies) {
       const componentPath = path.join(
         targetPath,
-        "craftrn-ui",
-        "components",
+        componentsBasePath,
         dep
       );
 
@@ -81,9 +90,17 @@ export async function addCommand(
         continue;
       }
 
-      await copyComponent(dep, targetPath);
+      await copyComponent(dep, targetPath, componentsBasePath);
+
+      if (options.fileSplitMode && options.fileSplitMode !== "none") {
+        const componentDir = path.join(targetPath, componentsBasePath, dep);
+        await splitComponentFiles(componentDir, dep, options.fileSplitMode);
+      }
+
       copySpinner.text = `Copied component ${dep}...`;
     }
+
+    await applyBarrelFileMode(targetPath, componentsBasePath, barrelFileMode);
 
     copySpinner.succeed(
       `Successfully copied ${dependencies.length} component(s)`
@@ -112,10 +129,17 @@ export async function addCommand(
 
     if (entryFile) {
       try {
+        const importTarget =
+          barrelFileMode === "folder"
+            ? `${componentsBasePath}`
+            : barrelFileMode === "none"
+              ? `${componentsBasePath}/${componentName}/${componentName}`
+              : `${componentsBasePath}/${componentName}`;
+
         const componentImportPath = await determineImportPath(
           targetPath,
           entryFile,
-          `craftrn-ui/components/${componentName}`
+          importTarget
         );
         console.log(
           chalk.gray(
@@ -124,17 +148,31 @@ export async function addCommand(
         );
       } catch {
         // Fallback to relative import
+        const fallbackImportPath =
+          barrelFileMode === "folder"
+            ? `./${componentsBasePath}`
+            : barrelFileMode === "none"
+              ? `./${componentsBasePath}/${componentName}/${componentName}`
+              : `./${componentsBasePath}/${componentName}`;
+
         console.log(
           chalk.gray(
-            `import { ${componentName} } from './craftrn-ui/components/${componentName}';`
+            `import { ${componentName} } from '${fallbackImportPath}';`
           )
         );
       }
     } else {
       // Fallback to relative import
+      const fallbackImportPath =
+        barrelFileMode === "folder"
+          ? `./${componentsBasePath}`
+          : barrelFileMode === "none"
+            ? `./${componentsBasePath}/${componentName}/${componentName}`
+            : `./${componentsBasePath}/${componentName}`;
+
       console.log(
         chalk.gray(
-          `import { ${componentName} } from './craftrn-ui/components/${componentName}';`
+          `import { ${componentName} } from '${fallbackImportPath}';`
         )
       );
     }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -6,8 +6,27 @@ export interface ComponentInfo {
   tetrislyIcons: string[];
 }
 
+/** Default destination for copied component source files. */
+export const DEFAULT_COMPONENTS_PATH = "craftrn-ui/components";
+
+/** How the user wants each component's source files structured. */
+export type FileSplitMode = 'none' | 'three' | 'four';
+
+/** How index barrel files should be handled for installed components. */
+export type BarrelFileMode = 'component' | 'folder' | 'none';
+
+/** Preferences collected from the interactive prompts before installation. */
+export interface UserPreferences {
+  fileSplitMode: FileSplitMode;
+  componentsPath: string;
+  barrelFileMode: BarrelFileMode;
+}
+
 export interface InstallOptions {
   componentName: string;
   force?: boolean;
   all?: boolean;
+  fileSplitMode?: FileSplitMode;
+  componentsPath?: string;
+  barrelFileMode?: BarrelFileMode;
 }

--- a/cli/src/utils/barrel-manager.ts
+++ b/cli/src/utils/barrel-manager.ts
@@ -1,0 +1,138 @@
+import * as fs from "fs-extra";
+import * as path from "path";
+import { BarrelFileMode } from "../types";
+
+function toPosixPath(value: string): string {
+	return value.replace(/\\+/g, "/").replace(/\/+$/, "");
+}
+
+async function getComponentEntryExportPath(
+	componentsRoot: string,
+	componentName: string
+): Promise<string | null> {
+	const componentDir = path.join(componentsRoot, componentName);
+	const tsxFile = path.join(componentDir, `${componentName}.tsx`);
+	const tsFile = path.join(componentDir, `${componentName}.ts`);
+
+	if (await fs.pathExists(tsxFile)) {
+		return `./${toPosixPath(componentName)}/${componentName}`;
+	}
+
+	if (await fs.pathExists(tsFile)) {
+		return `./${toPosixPath(componentName)}/${componentName}`;
+	}
+
+	return null;
+}
+
+async function listComponentNames(componentsRoot: string): Promise<string[]> {
+	if (!(await fs.pathExists(componentsRoot))) {
+		return [];
+	}
+
+	const entries = await fs.readdir(componentsRoot);
+	const names: string[] = [];
+
+	for (const entry of entries) {
+		const fullPath = path.join(componentsRoot, entry);
+		const stat = await fs.stat(fullPath);
+
+		if (!stat.isDirectory()) {
+			continue;
+		}
+
+		const exportPath = await getComponentEntryExportPath(componentsRoot, entry);
+		if (exportPath) {
+			names.push(entry);
+		}
+	}
+
+	names.sort((a, b) => a.localeCompare(b));
+	return names;
+}
+
+async function removeComponentIndexes(componentsRoot: string): Promise<void> {
+	const componentNames = await listComponentNames(componentsRoot);
+
+	for (const componentName of componentNames) {
+		const indexPath = path.join(componentsRoot, componentName, "index.ts");
+		if (await fs.pathExists(indexPath)) {
+			await fs.remove(indexPath);
+		}
+	}
+}
+
+async function ensureComponentIndexes(componentsRoot: string): Promise<void> {
+	const componentNames = await listComponentNames(componentsRoot);
+
+	for (const componentName of componentNames) {
+		const hasTsx = await fs.pathExists(
+			path.join(componentsRoot, componentName, `${componentName}.tsx`)
+		);
+		const hasTs = await fs.pathExists(
+			path.join(componentsRoot, componentName, `${componentName}.ts`)
+		);
+
+		if (!hasTsx && !hasTs) {
+			continue;
+		}
+
+		const indexPath = path.join(componentsRoot, componentName, "index.ts");
+		const expected = `export * from './${componentName}';\n`;
+		await fs.writeFile(indexPath, expected, "utf8");
+	}
+}
+
+async function writeFolderIndex(componentsRoot: string): Promise<void> {
+	const componentNames = await listComponentNames(componentsRoot);
+	const lines: string[] = [];
+
+	for (const componentName of componentNames) {
+		const exportPath = await getComponentEntryExportPath(componentsRoot, componentName);
+		if (!exportPath) {
+			continue;
+		}
+
+		lines.push(`export * from '${exportPath}';`);
+	}
+
+	const content = lines.length > 0 ? `${lines.join("\n")}\n` : "";
+	await fs.writeFile(path.join(componentsRoot, "index.ts"), content, "utf8");
+}
+
+async function removeFolderIndex(componentsRoot: string): Promise<void> {
+	const folderIndexPath = path.join(componentsRoot, "index.ts");
+	if (await fs.pathExists(folderIndexPath)) {
+		await fs.remove(folderIndexPath);
+	}
+}
+
+/**
+ * Applies the selected barrel/index strategy across the installed components root.
+ */
+export async function applyBarrelFileMode(
+	targetPath: string,
+	componentsBasePath: string,
+	barrelFileMode: BarrelFileMode
+): Promise<void> {
+	const componentsRoot = path.join(targetPath, componentsBasePath);
+
+	if (!(await fs.pathExists(componentsRoot))) {
+		return;
+	}
+
+	if (barrelFileMode === "component") {
+		await removeFolderIndex(componentsRoot);
+		await ensureComponentIndexes(componentsRoot);
+		return;
+	}
+
+	if (barrelFileMode === "folder") {
+		await removeComponentIndexes(componentsRoot);
+		await writeFolderIndex(componentsRoot);
+		return;
+	}
+
+	await removeFolderIndex(componentsRoot);
+	await removeComponentIndexes(componentsRoot);
+}

--- a/cli/src/utils/component-manager.ts
+++ b/cli/src/utils/component-manager.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs-extra";
 import * as path from "path";
-import { ComponentInfo } from "../types";
+import { ComponentInfo, DEFAULT_COMPONENTS_PATH } from "../types";
 import { ensureComponentsDownloaded } from "./github-downloader";
 
 interface SourcePaths {
@@ -116,16 +116,12 @@ export async function resolveDependencies(
  */
 export async function copyComponent(
   componentName: string,
-  targetPath: string
+  targetPath: string,
+  componentsBasePath: string = DEFAULT_COMPONENTS_PATH
 ): Promise<void> {
   const { componentsPath } = await ensureSourcePaths();
   const sourcePath = path.join(componentsPath, componentName);
-  const destPath = path.join(
-    targetPath,
-    "craftrn-ui",
-    "components",
-    componentName
-  );
+  const destPath = path.join(targetPath, componentsBasePath, componentName);
 
   if (!(await fs.pathExists(sourcePath))) {
     throw new Error(
@@ -147,7 +143,7 @@ export async function copyThemes(targetPath: string): Promise<void> {
   if (!(await fs.pathExists(themesPath))) {
     throw new Error(
       `Themes source not found at: ${themesPath}\n` +
-        `Current working directory: ${process.cwd()}`
+      `Current working directory: ${process.cwd()}`
     );
   }
 

--- a/cli/src/utils/file-splitter.ts
+++ b/cli/src/utils/file-splitter.ts
@@ -1,0 +1,474 @@
+import * as fs from "fs-extra";
+import * as path from "path";
+import { FileSplitMode } from "../types";
+
+// ─── Segment types ───────────────────────────────────────────────────────────
+
+type SegmentKind = "import" | "type" | "style" | "util" | "component";
+
+interface Segment {
+	content: string;
+	kind: SegmentKind;
+}
+
+// ─── Parser ──────────────────────────────────────────────────────────────────
+
+/**
+ * Split TypeScript source into top-level declaration segments.
+ *
+ * Strategy: track bracket depth and string/comment state character by
+ * character; emit a segment each time a semicolon is encountered at depth 0.
+ * This handles the vast majority of TypeScript top-level declarations (imports,
+ * type aliases, interfaces, const/function declarations, StyleSheet.create).
+ */
+function parseTopLevelSegments(source: string): string[] {
+	const segments: string[] = [];
+	let depth = 0;
+	let inString: '"' | "'" | "`" | null = null;
+	let inLineComment = false;
+	let inBlockComment = false;
+	let i = 0;
+	const n = source.length;
+
+	// segStart tracks the beginning of the current segment (in source indices).
+	// Skip leading whitespace so segments don't begin with blank lines.
+	while (i < n && /\s/.test(source[i])) i++;
+	let segStart = i;
+
+	while (i < n) {
+		const ch = source[i];
+		const next = source[i + 1] ?? "";
+
+		// ── Line comment ────────────────────────────────────────────────────────
+		if (!inString && !inBlockComment && ch === "/" && next === "/") {
+			inLineComment = true;
+			i += 2;
+			continue;
+		}
+		if (inLineComment) {
+			if (ch === "\n") inLineComment = false;
+			i++;
+			continue;
+		}
+
+		// ── Block comment ───────────────────────────────────────────────────────
+		if (!inString && ch === "/" && next === "*") {
+			inBlockComment = true;
+			i += 2;
+			continue;
+		}
+		if (inBlockComment) {
+			if (ch === "*" && next === "/") {
+				inBlockComment = false;
+				i += 2;
+			} else {
+				i++;
+			}
+			continue;
+		}
+
+		// ── Template literals ───────────────────────────────────────────────────
+		if (inString === "`") {
+			if (ch === "\\") {
+				i += 2;
+				continue;
+			}
+			if (ch === "`") inString = null;
+			i++;
+			continue;
+		}
+
+		// ── Regular strings ─────────────────────────────────────────────────────
+		if (inString) {
+			if (ch === "\\") {
+				i += 2;
+				continue;
+			}
+			if (ch === inString) inString = null;
+			i++;
+			continue;
+		}
+
+		// ── String open ─────────────────────────────────────────────────────────
+		if (ch === '"' || ch === "'" || ch === "`") {
+			inString = ch;
+			i++;
+			continue;
+		}
+
+		// ── Bracket depth ───────────────────────────────────────────────────────
+		if (ch === "{" || ch === "(" || ch === "[") depth++;
+		if (ch === "}" || ch === ")" || ch === "]") depth--;
+
+		// ── Segment boundary ────────────────────────────────────────────────────
+		if (ch === ";" && depth === 0) {
+			const seg = source.slice(segStart, i + 1).trim();
+			if (seg && seg !== ";") segments.push(seg);
+			i++;
+			// Skip whitespace between segments
+			while (i < n && /\s/.test(source[i])) i++;
+			segStart = i;
+			continue;
+		}
+
+		i++;
+	}
+
+	// Catch any trailing content (shouldn't normally exist in valid TS)
+	const remaining = source.slice(segStart).trim();
+	if (remaining && remaining !== ";") segments.push(remaining);
+
+	return segments;
+}
+
+// ─── Classifier ──────────────────────────────────────────────────────────────
+
+/**
+ * Return the first meaningful (non-comment) line of a segment so classification
+ * regexes don't accidentally match JSDoc text.
+ */
+function firstCodeLine(segment: string): string {
+	const stripped = segment
+		.replace(/\/\*[\s\S]*?\*\//g, "") // block comments
+		.replace(/\/\/.*/g, ""); // line comments
+	return stripped.trimStart().split("\n")[0].trim();
+}
+
+function classifySegment(segment: string, componentName: string): SegmentKind {
+	const first = firstCodeLine(segment);
+
+	if (first.startsWith("import ")) return "import";
+
+	if (/^(?:export\s+)?(?:type|interface)\s+/.test(first)) return "type";
+
+	if (/^(?:export\s+)?const\s+styles\s*=\s*StyleSheet\.create/.test(first))
+		return "style";
+
+	// Primary component: export const/function ComponentName…
+	if (
+		new RegExp(
+			`^export\\s+(?:default\\s+)?(?:const|function)\\s+${componentName}[\\s<(]`
+		).test(first)
+	) {
+		return "component";
+	}
+
+	return "util";
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Return the declared identifier name from a segment (exported or not). */
+function getDeclaredName(segment: string): string | null {
+	const first = firstCodeLine(segment);
+	const match = first.match(
+		/^(?:export\s+(?:default\s+)?)?(?:const|function|type|interface|class|enum|let|var)\s+(\w+)/
+	);
+	return match ? match[1] : null;
+}
+
+/**
+ * Add `export` to a declaration if it doesn't already have it.
+ * Works after JSDoc comment prefixes.
+ */
+function makeExported(segment: string): string {
+	if (/^export\s/.test(firstCodeLine(segment))) return segment;
+	// Insert 'export ' before the first declaration keyword
+	return segment.replace(
+		/\b(const|function|class|let|var|type|interface)(\s+\w)/,
+		"export $1$2"
+	);
+}
+
+/**
+ * Remove all named/default imports from a single-module import that are NOT
+ * mentioned in `keepNames`. Returns null if the result would be an empty
+ * import (side-effect imports are always kept).
+ */
+function filterImportStatement(
+	importStmt: string,
+	keepNames: Set<string>
+): string | null {
+	// Side-effect import: import 'module'  — always keep
+	if (/^import\s+['"]/.test(importStmt)) return importStmt;
+
+	// Collect what's kept
+	let result = importStmt;
+
+	// Remove named imports that aren't needed: { A, B, C }
+	result = result.replace(/\{([^}]*)\}/, (_match, inner: string) => {
+		const kept = inner
+			.split(",")
+			.map((s) => s.trim())
+			.filter((s) => {
+				if (!s) return false;
+				// Handle "X as Y" and "type X"
+				const name = s.split(/\s+/).pop()!;
+				return keepNames.has(name);
+			});
+		return kept.length ? `{ ${kept.join(", ")} }` : "";
+	});
+
+	// Remove default import if not needed
+	result = result.replace(
+		/^(import\s+)(\w+)(,?\s*)/,
+		(_m, prefix: string, name: string, comma: string) => {
+			if (keepNames.has(name)) return _m;
+			// Strip default import; keep the rest
+			return prefix + (comma.includes(",") ? "" : "");
+		}
+	);
+
+	// Remove namespace import if not needed
+	result = result.replace(/\*\s+as\s+(\w+)/, (_m, name: string) => {
+		return keepNames.has(name) ? _m : "";
+	});
+
+	// Clean up empty braces and stray commas
+	result = result
+		.replace(/,\s*\{\s*\}/, "")
+		.replace(/\{\s*\},?\s*/, "")
+		.replace(/,\s*from/, " from")
+		.replace(/import\s+from/, "import from"); // shouldn't happen, guard
+
+	// If nothing left between `import` and `from`, it's an empty import
+	if (/^import\s+from\s+['"]/.test(result.trim())) return null;
+	if (/^import\s*;/.test(result.trim())) return null;
+
+	return result.trim();
+}
+
+/** Extract every identifier name referenced in a code string. */
+function identifiersIn(code: string): Set<string> {
+	const matches = code.match(/\b[A-Za-z_$][\w$]*\b/g) ?? [];
+	return new Set(matches);
+}
+
+/** Extract all identifiers imported by an import statement. */
+function importedNames(importStmt: string): string[] {
+	const names: string[] = [];
+
+	// Default import
+	const defaultMatch = importStmt.match(/^import\s+(\w+)(?:\s*,|\s+from)/);
+	if (defaultMatch) names.push(defaultMatch[1]);
+
+	// Named imports { A, B as C }
+	const namedMatch = importStmt.match(/\{([^}]+)\}/);
+	if (namedMatch) {
+		namedMatch[1].split(",").forEach((s) => {
+			const name = s.trim().split(/\s+/).pop();
+			if (name) names.push(name);
+		});
+	}
+
+	// Namespace import * as X
+	const nsMatch = importStmt.match(/\*\s+as\s+(\w+)/);
+	if (nsMatch) names.push(nsMatch[1]);
+
+	return names;
+}
+
+/**
+ * From the original import statements, keep only those (or parts thereof)
+ * that are actually referenced in `targetCode`.
+ */
+function relevantImports(imports: string[], targetCode: string): string[] {
+	const usedIds = identifiersIn(targetCode);
+	const result: string[] = [];
+
+	for (const imp of imports) {
+		const names = importedNames(imp);
+		const needed = new Set(names.filter((n) => usedIds.has(n)));
+		if (needed.size === 0) continue;
+		const filtered = filterImportStatement(imp, needed);
+		if (filtered) result.push(filtered);
+	}
+
+	return result;
+}
+
+/** Join non-empty parts with double newlines and ensure trailing newline. */
+function buildFile(...parts: (string | string[])[]): string {
+	const flat = parts
+		.flat()
+		.map((s) => s.trim())
+		.filter(Boolean);
+	return flat.join("\n\n") + "\n";
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Split a component's main `.tsx` file into 3 or 4 files in-place.
+ *
+ * **Three files** (`mode === 'three'`):
+ *   - `ComponentName.types.ts`  — type & interface declarations
+ *   - `ComponentName.styles.ts` — StyleSheet.create block
+ *   - `ComponentName.tsx`       — component + utility declarations
+ *
+ * **Four files** (`mode === 'four'`):
+ *   - `ComponentName.types.ts`  — type & interface declarations
+ *   - `ComponentName.styles.ts` — StyleSheet.create block
+ *   - `ComponentName.utils.ts`  — standalone helper functions and hooks
+ *   - `ComponentName.tsx`       — component only
+ *
+ * The function rewrites the main `.tsx` file and creates the new files.
+ * The `index.ts` is left untouched — public types that were originally
+ * exported are re-exported from the main `.tsx` so existing consumers continue
+ * to work.
+ */
+export async function splitComponentFiles(
+	componentDir: string,
+	componentName: string,
+	mode: Exclude<FileSplitMode, "none">
+): Promise<void> {
+	const mainFile = path.join(componentDir, `${componentName}.tsx`);
+	if (!(await fs.pathExists(mainFile))) return;
+
+	const source = await fs.readFile(mainFile, "utf8");
+	const rawSegments = parseTopLevelSegments(source);
+
+	const classified: Segment[] = rawSegments.map((content) => ({
+		content,
+		kind: classifySegment(content, componentName),
+	}));
+
+	const imports = classified
+		.filter((s) => s.kind === "import")
+		.map((s) => s.content);
+	const typeSegs = classified
+		.filter((s) => s.kind === "type")
+		.map((s) => s.content);
+	const styleSegs = classified
+		.filter((s) => s.kind === "style")
+		.map((s) => s.content);
+	const utilSegs = classified
+		.filter((s) => s.kind === "util")
+		.map((s) => s.content);
+	const componentSegs = classified
+		.filter((s) => s.kind === "component")
+		.map((s) => s.content);
+
+	// Nothing to split — bail out silently
+	if (typeSegs.length === 0 && styleSegs.length === 0) return;
+
+	// ── Types file ─────────────────────────────────────────────────────────────
+	const exportedTypes = typeSegs.map(makeExported);
+	const typeNames = exportedTypes
+		.map(getDeclaredName)
+		.filter((n): n is string => n !== null);
+	const originallyExportedTypeNames = typeSegs
+		.filter((t) => /^export\s/m.test(firstCodeLine(t)))
+		.map(getDeclaredName)
+		.filter((n): n is string => n !== null);
+
+	const typesCode = exportedTypes.join("\n\n");
+	const typesImports = relevantImports(imports, typesCode);
+
+	await fs.writeFile(
+		path.join(componentDir, `${componentName}.types.ts`),
+		buildFile(typesImports, exportedTypes),
+		"utf8"
+	);
+
+	// ── Styles file ─────────────────────────────────────────────────────────────
+	if (styleSegs.length > 0) {
+		const stylesCode = styleSegs.join("\n\n");
+		const stylesImports = relevantImports(imports, stylesCode);
+
+		// Types referenced inside the styles declaration
+		const typeNamesUsedInStyles = typeNames.filter((n) =>
+			new RegExp(`\\b${n}\\b`).test(stylesCode)
+		);
+		const localTypesImport =
+			typeNamesUsedInStyles.length > 0
+				? `import type { ${typeNamesUsedInStyles.join(", ")} } from './${componentName}.types';`
+				: null;
+
+		// Export the styles object so the component can import it
+		const exportedStyleSegs = styleSegs.map((seg) =>
+			/^export\s/.test(firstCodeLine(seg)) ? seg : `export ${seg}`
+		);
+
+		await fs.writeFile(
+			path.join(componentDir, `${componentName}.styles.ts`),
+			buildFile(stylesImports, localTypesImport ?? [], exportedStyleSegs),
+			"utf8"
+		);
+	}
+
+	// ── Utils file (4-file mode) ───────────────────────────────────────────────
+	const exportedUtilNames: string[] = [];
+
+	if (mode === "four" && utilSegs.length > 0) {
+		const utilsCode = utilSegs.join("\n\n");
+		const utilsImports = relevantImports(imports, utilsCode);
+
+		const typeNamesUsedInUtils = typeNames.filter((n) =>
+			new RegExp(`\\b${n}\\b`).test(utilsCode)
+		);
+		const localTypesImport =
+			typeNamesUsedInUtils.length > 0
+				? `import type { ${typeNamesUsedInUtils.join(", ")} } from './${componentName}.types';`
+				: null;
+
+		const exportedUtils = utilSegs.map(makeExported);
+		exportedUtilNames.push(
+			...exportedUtils
+				.map(getDeclaredName)
+				.filter((n): n is string => n !== null)
+		);
+
+		await fs.writeFile(
+			path.join(componentDir, `${componentName}.utils.ts`),
+			buildFile(utilsImports, localTypesImport ?? [], exportedUtils),
+			"utf8"
+		);
+	}
+
+	// ── Component file (rewrite .tsx) ──────────────────────────────────────────
+	// In 3-file mode, utils stay in the component file.
+	const componentBody =
+		mode === "three"
+			? [...utilSegs, ...componentSegs]
+			: [...componentSegs];
+
+	const componentBodyCode = componentBody.join("\n\n");
+	const componentImports = relevantImports(imports, componentBodyCode);
+
+	// Local imports from the files we just created
+	const localImports: string[] = [];
+
+	if (typeNames.length > 0) {
+		localImports.push(
+			`import type { ${typeNames.join(", ")} } from './${componentName}.types';`
+		);
+	}
+	if (styleSegs.length > 0) {
+		localImports.push(
+			`import { styles } from './${componentName}.styles';`
+		);
+	}
+	if (mode === "four" && exportedUtilNames.length > 0) {
+		localImports.push(
+			`import { ${exportedUtilNames.join(", ")} } from './${componentName}.utils';`
+		);
+	}
+
+	// Re-export originally-public types so index.ts keeps working unchanged
+	const reExports =
+		originallyExportedTypeNames.length > 0
+			? `export type { ${originallyExportedTypeNames.join(", ")} } from './${componentName}.types';`
+			: null;
+
+	await fs.writeFile(
+		mainFile,
+		buildFile(
+			componentImports,
+			localImports,
+			componentBody,
+			reExports ?? []
+		),
+		"utf8"
+	);
+}

--- a/cli/src/utils/prompts.ts
+++ b/cli/src/utils/prompts.ts
@@ -1,0 +1,131 @@
+import { cancel, intro, isCancel, outro, select, text } from "@clack/prompts";
+import {
+	BarrelFileMode,
+	DEFAULT_COMPONENTS_PATH,
+	FileSplitMode,
+	UserPreferences,
+} from "../types";
+
+/**
+ * Runs the interactive prompts and returns the collected user preferences.
+ * Returns null if the user cancels at any point.
+ *
+ * Designed to be extended with additional prompts in future iterations —
+ * just add more prompt calls and fields to UserPreferences.
+ */
+export async function collectUserPreferences(): Promise<UserPreferences | null> {
+	intro("craftrn-ui — component options");
+
+	// ── Prompt 1: file structure ────────────────────────────────────────────
+	const fileSplitMode = await select({
+		message: "How would you like to structure each component?",
+		options: [
+			{
+				value: "none" as FileSplitMode,
+				label: "Single file",
+				hint: "Keep the original file structure as-is",
+			},
+			{
+				value: "three" as FileSplitMode,
+				label: "Three files",
+				hint: "types · styles · component",
+			},
+			{
+				value: "four" as FileSplitMode,
+				label: "Four files",
+				hint: "types · styles · component · utils & hooks",
+			},
+		],
+	});
+
+	if (isCancel(fileSplitMode)) {
+		cancel("Operation cancelled.");
+		return null;
+	}
+
+	// ── Prompt 2: component destination folder ─────────────────────────────
+	const destinationMode = await select({
+		message: `Where should component files be stored? (current default: ${DEFAULT_COMPONENTS_PATH})`,
+		options: [
+			{
+				value: "default",
+				label: `Use default (${DEFAULT_COMPONENTS_PATH})`,
+				hint: "Recommended for standard setup",
+			},
+			{
+				value: "custom",
+				label: "Use custom path",
+				hint: "Example: src/components/ui",
+			},
+		],
+	});
+
+	if (isCancel(destinationMode)) {
+		cancel("Operation cancelled.");
+		return null;
+	}
+
+	let componentsPath = DEFAULT_COMPONENTS_PATH;
+
+	if (destinationMode === "custom") {
+		const customPath = await text({
+			message: `Enter component destination path (default is ${DEFAULT_COMPONENTS_PATH})`,
+			placeholder: "src/components/ui",
+			validate(value) {
+				const trimmed = (value ?? "").trim();
+				if (!trimmed) {
+					return "Path is required.";
+				}
+
+				// Keep the path project-relative for predictable imports and copies.
+				if (/^([a-zA-Z]:)?[\\/]/.test(trimmed)) {
+					return "Use a project-relative path (for example: src/components/ui).";
+				}
+
+				return undefined;
+			},
+		});
+
+		if (isCancel(customPath)) {
+			cancel("Operation cancelled.");
+			return null;
+		}
+
+		componentsPath = customPath.trim().replace(/\\+/g, "/");
+	}
+
+	// ── Future prompts go here ──────────────────────────────────────────────
+	const barrelFileMode = await select({
+		message: "How should index barrel files be handled?",
+		options: [
+			{
+				value: "component" as BarrelFileMode,
+				label: "Per component",
+				hint: "Keep or create index.ts inside each component folder",
+			},
+			{
+				value: "folder" as BarrelFileMode,
+				label: "Whole components folder",
+				hint: "Create one index.ts in the components root",
+			},
+			{
+				value: "none" as BarrelFileMode,
+				label: "No index files",
+				hint: "Do not create index.ts barrels",
+			},
+		],
+	});
+
+	if (isCancel(barrelFileMode)) {
+		cancel("Operation cancelled.");
+		return null;
+	}
+
+	outro("Got it — installing component(s)…");
+
+	return {
+		fileSplitMode: fileSplitMode as FileSplitMode,
+		componentsPath,
+		barrelFileMode: barrelFileMode as BarrelFileMode,
+	};
+}


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
The `add` command currently assumes one fixed output structure (`craftrn-ui/components` with per-component `index.ts` behavior) and one file layout style. Teams with different folder conventions or import preferences need to manually move/split files after install, which adds friction and inconsistencies.

**Describe the solution you'd like**
This is a POC solution add an interactive preference step to `add` (collected once per command run) so installation behavior can be configured up front.

I haven't tested this severily yet, and relied heavily on AI for implementation and testing due to not being familiar with developing CLI tools, so I want to share the implementation details and testing status here for transparency and feedback. 

Implemented capabilities:
- Prompted install preferences once per run, including `add --all`.
- File split mode options:
  - `none` (keep original single-file layout)
  - `three` (types + styles + component)
  - `four` (types + styles + component + utils/hooks)
- Configurable component destination path:
  - default: `craftrn-ui/components`
  - custom project-relative path (example: `src/components/ui`)
- Barrel/index strategy options:
  - `component`: keep/create `index.ts` per component folder
  - `folder`: generate one root `index.ts` for installed components
  - `none`: remove both component and root index files
- Import example output adapts to selected barrel mode/path so generated usage hints stay correct.

Main implementation areas:
- `cli/src/cli.ts`
  - Collects preferences once with `collectUserPreferences()` and forwards to each `addCommand` call.
- `cli/src/types.ts`
  - Adds `DEFAULT_COMPONENTS_PATH`, `FileSplitMode`, `BarrelFileMode`, `UserPreferences`, and new install option fields.
- `cli/src/commands/add.ts`
  - Applies destination path, optional split processing, barrel mode application, and mode-aware import hints.
- `cli/src/utils/prompts.ts` (new)
  - Interactive prompt flow and validation for custom destination path.
- `cli/src/utils/file-splitter.ts` (new)
  - Splits component source into mode-specific file layouts.
- `cli/src/utils/barrel-manager.ts` (new)
  - Applies selected index/barrel strategy.
- `cli/src/utils/component-manager.ts`
  - `copyComponent` now supports configurable destination base path.
- `README.md`
  - Documents the new interactive `add` behavior.

Non implemented capabilities but highly-useful future additions:
- configuration file to persist preferences across runs without prompts (example: `.craftrnuirc`).

**Describe alternatives you've considered**
- Add CLI flags instead of prompts (for example `--path`, `--split`, `--barrel`).
  - Pros: scriptable CI usage.
  - Cons: more command complexity for most users.

Current approach prioritizes zero-config default UX while allowing customization in the same command flow.

**Additional context**
Validation/testing summary:
- Default install behavior with new preference plumbing.
- Custom destination path behavior and normalization.
- Split mode behavior (`none`, `three`, `four`).
- Barrel/index behavior (`component`, `folder`, `none`).
- Interactive cancel behavior.
- Prompt-once behavior for `add --all`.

Dependency updates:
- Added `@clack/prompts` for interactive UX.

Notes for reviewer:
- Backward compatibility is preserved through defaults (`craftrn-ui/components`, no split, component-level barrel behavior).
- Main risk area is splitter heuristics on unusual component source patterns; existing components pass current checks.

**Demo of usage:**


https://github.com/user-attachments/assets/70668746-320b-4f0c-9328-92cfd053b032

